### PR TITLE
Fix editing results when such an editing buffer already exists

### DIFF
--- a/helm-ag.el
+++ b/helm-ag.el
@@ -623,7 +623,8 @@ Default behaviour shows finish and result in mode-line."
                            default-directory))
          (default-directory helm-buf-dir))
     (with-current-buffer (get-buffer-create "*helm-ag-edit*")
-      (erase-buffer)
+      (let ((inhibit-read-only t))
+        (erase-buffer))
       (setq-local helm-ag--default-directory helm-buf-dir)
       (unless (helm-ag--vimgrep-option)
         (setq-local helm-ag--search-this-file-p


### PR DESCRIPTION
Since the editing buffer as some read-only text, attempting to erase it resulted
in an error message.